### PR TITLE
Add LED Support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,8 +182,13 @@ file(GLOB PROTOCOL_PIO_FILES CONFIGURE_DEPENDS
   ${CMAKE_SOURCE_DIR}/protocols/${PROTOCOL}/*.pio
 )
 
+# Define list of Common PIO files for compilation
+file(GLOB_RECURSE COMMON_PIO_FILES CONFIGURE_DEPENDS
+  ${CMAKE_SOURCE_DIR}/common/*.pio
+)
+
 # Loop through each PIO file and generate header.
-foreach(PIO_FILE IN LISTS PROTOCOL_PIO_FILES)
+foreach(PIO_FILE IN LISTS COMMON_PIO_FILES PROTOCOL_PIO_FILES)
   # Extract directory and filename without extension
   get_filename_component(PIO_DIR ${PIO_FILE} DIRECTORY)
   get_filename_component(PIO_NAME ${PIO_FILE} NAME_WE)

--- a/src/common/lib/hid_interface.c
+++ b/src/common/lib/hid_interface.c
@@ -25,7 +25,7 @@
 #include "bsp/board.h"
 #include "hid_keycodes.h"
 #include "keymaps.h"
-#include "lock_leds.h"
+#include "led_helper.h"
 #include "pico/bootrom.h"
 #include "tusb.h"
 #include "usb_descriptors.h"
@@ -112,6 +112,10 @@ void handle_keyboard_report(uint8_t code, bool make) {
         if (macro_key == KC_BOOT) {
           // Initiate Bootloader
           printf("[INFO] Initiate Bootloader\n");
+#ifdef CONVERTER_LEDS
+          // Set Status LED to indicate Bootloader Mode
+          update_converter_status(3);
+#endif
           // Reboot into Bootloader
           reset_usb_boot(0, 0);
         }

--- a/src/common/lib/led_helper.c
+++ b/src/common/lib/led_helper.c
@@ -1,0 +1,75 @@
+/*
+ * This file is part of RP2040 Keyboard Converter.
+ *
+ * Copyright 2023 Paul Bramhall (paulwamp@gmail.com)
+ *
+ * RP2040 Keyboard Converter is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * RP2040 Keyboard Converter is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RP2040 Keyboard Converter.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "led_helper.h"
+
+#ifdef CONVERTER_LEDS
+#include "ws2812/ws2812.h"
+#endif
+
+lock_keys_union lock_leds;
+uint8_t ps2_lock_values = 0;
+uint8_t converter_status = 0;
+
+#ifdef CONVERTER_LEDS
+void update_converter_leds(void) {
+  // Update the Status LED (Keep blank for now)
+  switch (converter_status) {
+    case 1:
+      ws2812_show(CONVERTER_LEDS_STATUS_READY_COLOR);
+      break;
+    case 2:
+      ws2812_show(CONVERTER_LEDS_STATUS_NOT_READY_COLOR);
+      break;
+    case 3:
+      ws2812_show(CONVERTER_LEDS_STATUS_FWFLASH_COLOR);
+      break;
+  }
+#ifdef CONVERTER_LOCK_LEDS
+  // Update the Lock LEDs
+  ws2812_show(lock_leds.keys.numLock ? CONVERTER_LOCK_LEDS_COLOR : 0);
+  ws2812_show(lock_leds.keys.capsLock ? CONVERTER_LOCK_LEDS_COLOR : 0);
+  ws2812_show(lock_leds.keys.scrollLock ? CONVERTER_LOCK_LEDS_COLOR : 0);
+#endif
+  // Add a small delay to ensure we respect the WS2812 timings to reset the data line, and also to prevent flickering
+  busy_wait_us(60);
+}
+
+void update_converter_status(uint8_t status) {
+  if (status != converter_status) {
+    converter_status = status;
+    update_converter_leds();
+  }
+}
+#endif
+
+void set_lock_values_from_hid(uint8_t lock_val) {
+  lock_leds.keys.numLock = (unsigned char)(lock_val & 0x01);
+  lock_leds.keys.capsLock = (unsigned char)((lock_val >> 1) & 0x01);
+  lock_leds.keys.scrollLock = (unsigned char)((lock_val >> 2) & 0x01);
+
+#ifdef CONVERTER_LEDS
+  update_converter_leds();
+#endif
+
+  // Update interface-specific lock values
+  // PS/2
+  ps2_lock_values = (uint8_t)((lock_leds.keys.capsLock << 2) | (lock_leds.keys.numLock << 1) | lock_leds.keys.scrollLock);
+}

--- a/src/common/lib/led_helper.h
+++ b/src/common/lib/led_helper.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of RP2040 Keyboard Converter.
+ *
+ * Copyright 2023 Paul Bramhall (paulwamp@gmail.com)
+ *
+ * RP2040 Keyboard Converter is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * RP2040 Keyboard Converter is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RP2040 Keyboard Converter.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LED_HELPER_H
+#define LED_HELPER_H
+
+#include <stdint.h>
+
+#include "config.h"
+
+// Define the LED Locklight Indicators
+typedef struct lock_keys {
+  unsigned char numLock : 1;
+  unsigned char capsLock : 1;
+  unsigned char scrollLock : 1;
+} lock_keys;
+
+typedef union lock_keys_union {
+  lock_keys keys;
+  unsigned char value;
+} lock_keys_union;
+
+extern lock_keys_union lock_leds;
+
+// Define the lock values for each interface
+extern uint8_t ps2_lock_values;
+
+void set_lock_values_from_hid(uint8_t lock_val);
+
+#ifdef CONVERTER_LEDS
+void update_converter_status(uint8_t status);
+#endif
+
+#endif /* LED_HELPER_H */

--- a/src/common/lib/pio_helper.c
+++ b/src/common/lib/pio_helper.c
@@ -18,17 +18,20 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "lock_leds.h"
+#include "pio_helper.h"
 
-lock_keys_union lock_leds;
-uint8_t hid_lock_values = 0;
-uint8_t ps2_lock_values = 0;
+#include <stdio.h>
 
-void set_lock_values_from_hid(uint8_t lock_val) {
-  lock_leds.keys.numLock = (unsigned char)(lock_val & 0x01);
-  lock_leds.keys.capsLock = (unsigned char)((lock_val >> 1) & 0x01);
-  lock_leds.keys.scrollLock = (unsigned char)((lock_val >> 2) & 0x01);
-
-  hid_lock_values = (uint8_t)lock_leds.value;
-  ps2_lock_values = (uint8_t)((lock_leds.keys.capsLock << 2) | (lock_leds.keys.numLock << 1) | lock_leds.keys.scrollLock);
+PIO find_available_pio(const pio_program_t *program) {
+  // This is a simple Helper Function which will check if there is space in either PIO0 or PIO1 for a given PIO Program.
+  if (!pio_can_add_program(pio0, program)) {
+    printf("[WARN] PIO0 has no space for PIO Program\nChecking to see if we can load into PIO1\n");
+    if (!pio_can_add_program(pio1, program)) {
+      printf("[ERR] PIO1 has no space for PIO Program\n");
+      return NULL;
+    }
+    return pio1;
+  } else {
+    return pio0;
+  }
 }

--- a/src/common/lib/pio_helper.h
+++ b/src/common/lib/pio_helper.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of RP2040 Keyboard Converter.
+ *
+ * Copyright 2023 Paul Bramhall (paulwamp@gmail.com)
+ *
+ * RP2040 Keyboard Converter is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * RP2040 Keyboard Converter is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RP2040 Keyboard Converter.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef PIO_HELPER_H
+#define PIO_HELPER_H
+
+#include "hardware/pio.h"
+
+PIO find_available_pio(const pio_program_t *program);
+
+#endif /* PIO_HELPER_H */

--- a/src/common/lib/types.h
+++ b/src/common/lib/types.h
@@ -3,6 +3,9 @@
  *
  * Copyright 2023 Paul Bramhall (paulwamp@gmail.com)
  *
+ * Portions of this specific file are licensed under the MIT License.
+ * The original source can be found at: https://github.com/Zheoni/pico-simon
+ *
  * RP2040 Keyboard Converter is free software: you can redistribute it
  * and/or modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -18,28 +21,19 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef LOCK_LEDS_H
-#define LOCK_LEDS_H
+#ifndef TYPES_H
+#define TYPES_H
 
-#include <stdint.h>
+// This contains some standard type values which are used throughout the codebase.
 
-// Define the LED Locklight Indicators
-typedef struct lock_keys {
-  unsigned char numLock : 1;
-  unsigned char capsLock : 1;
-  unsigned char scrollLock : 1;
-} lock_keys;
+enum led_types {
+  // Define the different types of LED which we can use
+  LED_RGB = 0x00,  // 0x00 /* RGB LED Type */
+  LED_RBG,         // 0x01 /* RBG LED Type */
+  LED_GRB,         // 0x02 /* GRB LED Type */
+  LED_GBR,         // 0x03 /* GBR LED Type */
+  LED_BRG,         // 0x04 /* BRG LED Type */
+  LED_BGR,         // 0x05 /* BGR LED Type */
+};
 
-typedef union lock_keys_union {
-  lock_keys keys;
-  unsigned char value;
-} lock_keys_union;
-
-extern lock_keys_union lock_leds;
-
-extern uint8_t hid_lock_values;
-extern uint8_t ps2_lock_values;
-
-void set_lock_values_from_hid(uint8_t lock_val);
-
-#endif /* LOCK_LEDS_H */
+#endif /* TYPES_H */

--- a/src/common/lib/ws2812/ws2812.c
+++ b/src/common/lib/ws2812/ws2812.c
@@ -1,0 +1,87 @@
+/*
+ * This file is part of RP2040 Keyboard Converter.
+ *
+ * Copyright 2023 Paul Bramhall (paulwamp@gmail.com)
+ *
+ * RP2040 Keyboard Converter is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * RP2040 Keyboard Converter is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RP2040 Keyboard Converter.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#ifdef CONVERTER_LEDS
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "bsp/board.h"
+#include "pio_helper.h"
+#include "ws2812.h"
+#include "ws2812.pio.h"
+
+uint ws2812_sm = 0;
+uint ws2812_offset = 0;
+PIO ws2812_pio = NULL;
+
+static inline uint32_t ws2812_set_color(uint32_t led_color) {
+  // Adjust color values to set brightness
+  uint8_t r = (led_color >> 16) & 0xFF;
+  uint8_t g = (led_color >> 8) & 0xFF;
+  uint8_t b = led_color & 0xFF;
+  r = (r * CONVERTER_LEDS_BRIGHTNESS) / 20;
+  g = (g * CONVERTER_LEDS_BRIGHTNESS) / 20;
+  b = (b * CONVERTER_LEDS_BRIGHTNESS) / 20;
+
+  // Apply color order based on CONVERTER_LEDS_TYPE
+  switch (CONVERTER_LEDS_TYPE) {
+    case LED_RBG:
+      return (r << 16) | (b << 8) | g;
+    case LED_GRB:
+      return (g << 16) | (r << 8) | b;
+    case LED_GBR:
+      return (g << 16) | (b << 8) | r;
+    case LED_BRG:
+      return (b << 16) | (r << 8) | g;
+    case LED_BGR:
+      return (b << 16) | (g << 8) | r;
+    default:  // LED_RGB
+      return (r << 16) | (g << 8) | b;
+  }
+}
+
+void ws2812_show(uint32_t led_color) {
+  pio_sm_put_blocking(ws2812_pio, ws2812_sm, ws2812_set_color(led_color) << 8u);
+}
+
+void ws2812_setup(uint led_pin) {
+  ws2812_pio = find_available_pio(&ws2812_program);
+  if (ws2812_pio == NULL) {
+    printf("[ERR] No PIO available for WS2812 Program\n");
+    return;
+  }
+
+  ws2812_sm = (uint)pio_claim_unused_sm(ws2812_pio, true);
+  ws2812_offset = pio_add_program(ws2812_pio, &ws2812_program);
+
+  float rp_clock_khz = 0.001 * clock_get_hz(clk_sys);
+  float clock_div = roundf(rp_clock_khz / (800 * 10));
+
+  printf("[INFO] Effective SM Clock Speed: %.2fkHz\n", (float)(rp_clock_khz / clock_div));
+
+  ws2812_program_init(ws2812_pio, ws2812_sm, ws2812_offset, led_pin, clock_div);
+
+  printf("[INFO] PIO%d SM%d WS2812 Interface program loaded at offset %d with clock divider of %.2f\n", ws2812_pio == pio0 ? 0 : 1, ws2812_sm, ws2812_offset, clock_div);
+}
+#endif

--- a/src/common/lib/ws2812/ws2812.h
+++ b/src/common/lib/ws2812/ws2812.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of RP2040 Keyboard Converter.
+ *
+ * Copyright 2023 Paul Bramhall (paulwamp@gmail.com)
+ *
+ * RP2040 Keyboard Converter is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * RP2040 Keyboard Converter is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RP2040 Keyboard Converter.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef WS2812_H
+#define WS2812_H
+
+#include "config.h"
+
+#ifdef CONVERTER_LEDS
+
+#include "pico/stdlib.h"
+
+void ws2812_show(uint32_t led_color);
+void ws2812_setup(uint data_pin);
+
+#endif
+
+#endif /* WS2812_H */

--- a/src/common/lib/ws2812/ws2812.pio
+++ b/src/common/lib/ws2812/ws2812.pio
@@ -1,0 +1,42 @@
+;
+; Original PIO Code is Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+;
+; SPDX-License-Identifier: BSD-3-Clause
+;
+
+.program ws2812
+.side_set 1
+
+.define public T1 2
+.define public T2 5
+.define public T3 3
+
+.wrap_target
+bitloop:
+    out x, 1       side 0 [T3 - 1] ; Side-set still takes place when instruction stalls
+    jmp !x do_zero side 1 [T1 - 1] ; Branch on the bit we shifted out. Positive pulse
+do_one:
+    jmp  bitloop   side 1 [T2 - 1] ; Continue driving high, for a long pulse
+do_zero:
+    nop            side 0 [T2 - 1] ; Or drive low, for a short pulse
+.wrap
+
+% c-sdk {
+#include "hardware/clocks.h"
+
+static inline void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, float div) {
+
+    pio_gpio_init(pio, pin);
+    pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, true);
+
+    pio_sm_config c = ws2812_program_get_default_config(offset);
+    sm_config_set_sideset_pins(&c, pin);
+    sm_config_set_out_shift(&c, false, true, 24);
+    // sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
+
+    sm_config_set_clkdiv(&c, div);
+    
+    pio_sm_init(pio, sm, offset, &c);
+    pio_sm_set_enabled(pio, sm, true);
+}
+%}

--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,28 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-// Define some Compile Time variables
+// Include some common type definitions for this config.h file
+#include "types.h"
+
+// Define configuration options for the Keyboard Converter
+#define CONVERTER_PIEZO              // Enable Piezo Buzzer on Converter Hardware
+#define CONVERTER_LEDS               // Enable support for LED indicator lights on Converter Hardware
+#define CONVERTER_LEDS_TYPE LED_GRB  // Define type of LED which we are using
+#define CONVERTER_LOCK_LEDS          // Enable Lock LED Indicators on Converter Hardware
+
+// Define the colors of the LEDs in HEX.  Regardless of LED Type, we always use RGB Value here.
+#define CONVERTER_LEDS_BRIGHTNESS 5                     // Brightness of LEDs.  This ranges from 1 to 10.
+#define CONVERTER_LEDS_STATUS_READY_COLOR 0x00FF00      // Color of Status LED when Converter is initialised
+#define CONVERTER_LEDS_STATUS_NOT_READY_COLOR 0xFF2800  // Color of Status LED when Converter is not ready
+#define CONVERTER_LEDS_STATUS_FWFLASH_COLOR 0xFF00FF    // Color of Status LED when in Bootloader Mode (Firmware Flashing)
+#define CONVERTER_LOCK_LEDS_COLOR 0x00FF00              // Color of Lock Light LEDs
+
+// Ensure you specify the correct DATA Pin for the connector.  Also, ensure CLK is connected to DATA+1
+#define DATA_PIN 6    // We assume that DATA and CLOCK are positioned next to each other, as such Clock will be DATA_PIN + 1
+#define PIEZO_PIN 11  // Piezo Buzzer GPIO Pin
+#define LED_PIN 5     // LED DATA Pin.  As we use WS2812 LEDs, all LEDs are driven from a single GPIO Pin
+
+// Define some Compile Time variables.  Do not modify below this line
 #define BUILD_TIME _BUILD_TIME
 #define KEYBOARD_MAKE _KEYBOARD_MAKE
 #define KEYBOARD_MODEL _KEYBOARD_MODEL
@@ -32,12 +53,11 @@
 #define KEYBOARD_PROTOCOL _KEYBOARD_PROTOCOL
 #define KEYBOARD_CODESET _KEYBOARD_CODESET
 
-// Ensure you specify the correct DATA Pin for the connector.  Also, ensure CLK is connected to DATA+1
-// #define DATA_PIN 16   // We assume that DATA and CLOCK are positioned next to each other, as such Clock will be DATA_PIN + 1
-#define DATA_PIN 6    // We assume that DATA and CLOCK are positioned next to each other, as such Clock will be DATA_PIN + 1
-#define PIEZO_PIN 11  // Piezo Buzzer GPIO Pin
-
-#define APPLE_EMULATED_NUMLOCK 1       // Apple Devices don't natively support Numlock, so we must emulate the functionality.
-#define APPLE_INITIAL_NUMLOCK_STATE 1  // Define NumLock State when emulating Apple devices (default ON)
+// Some Validation rules for the configuration
+#ifdef CONVERTER_LEDS_BRIGHTNESS
+#if CONVERTER_LEDS_BRIGHTNESS < 1 || CONVERTER_LEDS_BRIGHTNESS > 10
+#error "CONVERTER_LEDS_BRIGHTNESS must be between 1 and 10"
+#endif
+#endif
 
 #endif /* CONFIG_H */

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 
 #include "bsp/board.h"
-#include "buzzer.h"
 #include "config.h"
 #include "hid_interface.h"
 #include "interface.h"
@@ -34,6 +33,14 @@
 #include "pico/unique_id.h"
 #include "ringbuf.h"
 #include "tusb.h"
+
+// The following includes are optional and are only included if the relevant features are enabled.
+#ifdef CONVERTER_PIEZO
+#include "buzzer.h"
+#endif
+#ifdef CONVERTER_LEDS
+#include "ws2812/ws2812.h"
+#endif
 
 int main(void) {
   hid_device_setup();
@@ -44,17 +51,24 @@ int main(void) {
   printf("[INFO] RP2040 Serial ID: %s\n", pico_unique_id);
   printf("[INFO] Build Time: %s\n", BUILD_TIME);
   printf("--------------------------------\n");
+
+  // Initialise Optional Components
+#ifdef CONVERTER_PIEZO
+  buzzer_init(PIEZO_PIN);  // Setup the buzzer.
+#endif
+#ifdef CONVERTER_LEDS
+  ws2812_setup(LED_PIN);  // Setup the WS2812 LEDs.
+#endif
+
+  // Initialise aspects of the Interface.
   printf("[INFO] Keyboard Make: %s\n", KEYBOARD_MAKE);
   printf("[INFO] Keyboard Model: %s\n", KEYBOARD_MODEL);
   printf("[INFO] Keyboard Description: %s\n", KEYBOARD_DESCRIPTION);
   printf("[INFO] Keyboard Protocol: %s\n", KEYBOARD_PROTOCOL);
   printf("[INFO] Keyboard Scancode Set: %s\n", KEYBOARD_CODESET);
   printf("--------------------------------\n");
-
-  // Initialise aspects of the program.
   ringbuf_reset();                     // Even though Ringbuf is statically initialised, we reset it here to be sure it's empty.
   keyboard_interface_setup(DATA_PIN);  // Setup the keyboard interface.
-  buzzer_init(PIEZO_PIN);              // Setup the buzzer.
   printf("--------------------------------\n");
   while (1) {
     keyboard_interface_task();  // Keyboard interface task.

--- a/src/protocols/at/interface.pio
+++ b/src/protocols/at/interface.pio
@@ -105,7 +105,7 @@ static inline void keyboard_interface_program_init(PIO pio, uint sm, uint offset
 
   sm_config_set_clkdiv(&c, div);
 
-  pio_set_irq0_source_enabled(pio, pis_sm0_rx_fifo_not_empty, true);
+  pio_set_irq0_source_enabled(pio, pis_sm0_rx_fifo_not_empty + sm, true);
 
   pio_sm_init(pio, sm, offset, &c);
 

--- a/src/protocols/xt/interface.c
+++ b/src/protocols/xt/interface.c
@@ -25,10 +25,14 @@
 #include "bsp/board.h"
 #include "config.h"
 #include "hardware/clocks.h"
-#include "hardware/pio.h"
 #include "interface.pio.h"
+#include "pio_helper.h"
 #include "ringbuf.h"
 #include "scancode.h"
+
+#ifdef CONVERTER_LEDS
+#include "led_helper.h"
+#endif
 
 uint keyboard_sm = 0;
 uint offset = 0;
@@ -65,6 +69,9 @@ static void keyboard_event_processor(uint8_t data_byte) {
     case INITIALISED:
       if (!ringbuf_is_full()) ringbuf_put(data_byte);
   }
+#ifdef CONVERTER_LEDS
+  update_converter_status(keyboard_state == INITIALISED ? 1 : 2);
+#endif
 }
 
 // IRQ Event Handler used to read keycode data from the XT Keyboard
@@ -82,7 +89,6 @@ static void __isr keyboard_input_event_handler() {
     keyboard_pio_restart();
     return;
   }
-
   keyboard_event_processor(data_byte);
 }
 
@@ -137,9 +143,30 @@ void keyboard_interface_task() {
 
 // Public function to initialise the XT PIO interface.
 void keyboard_interface_setup(uint data_pin) {
+#ifdef CONVERTER_LEDS
+  update_converter_status(2);  // Always reset Converter Status here
+#endif
+
+  // First we need to determine which PIO to use for the Keyboard Interface.
+  // To do this, we check each PIO to see if there is space to load the Keyboard Interface program.
+  // If there is space, we claim the PIO and load the program.  If not, we continue to the next PIO.
+  // We can call `pio_can_add_program` to check if there is space for the program.
+  // `find_available_pio` is a helper function that will check both PIO0 and PIO1 for space.
+  // If the function returns NULL, then there is no space available, and we should return.
+
+  keyboard_pio = find_available_pio(&keyboard_interface_program);
+  if (keyboard_pio == NULL) {
+    printf("[ERR] No PIO available for Keyboard Interface Program\n");
+    return;
+  }
+
+  // Now we can claim the PIO and load the program.
   keyboard_sm = (uint)pio_claim_unused_sm(keyboard_pio, true);
   offset = pio_add_program(keyboard_pio, &keyboard_interface_program);
-  uint pio_irq = PIO1_IRQ_0;
+
+  // Define the IRQ for the PIO State Machine.
+  // This should either be set to PIO0_IRQ_0 or PIO1_IRQ_0 depending on the PIO used.
+  uint pio_irq = keyboard_pio == pio0 ? PIO0_IRQ_0 : PIO1_IRQ_0;
 
   // Define the Polling Inteval for the State Machine.
   // The XT Protocol runs at a clock speed of around 31kHz due to the clock
@@ -169,7 +196,7 @@ void keyboard_interface_setup(uint data_pin) {
 
   keyboard_interface_program_init(keyboard_pio, keyboard_sm, offset, data_pin, clock_div);
 
-  printf("[INFO] PIO SM Interface program loaded at %d with clock divider of %.2f\n", offset, clock_div);
+  printf("[INFO] PIO%d SM%d Interface program loaded at offset %d with clock divider of %.2f\n", (keyboard_pio == pio0 ? 0 : 1), keyboard_sm, offset, clock_div);
 
   irq_set_exclusive_handler(pio_irq, &keyboard_input_event_handler);
   irq_set_enabled(pio_irq, true);

--- a/src/protocols/xt/interface.pio
+++ b/src/protocols/xt/interface.pio
@@ -130,7 +130,7 @@ static inline void keyboard_interface_program_init(PIO pio, uint sm, uint offset
 
   sm_config_set_clkdiv(&c, div);
 
-  pio_set_irq0_source_enabled(pio, pis_sm0_rx_fifo_not_empty, true);
+  pio_set_irq0_source_enabled(pio, pis_sm0_rx_fifo_not_empty + sm, true);
 
   pio_sm_init(pio, sm, offset, &c);
 


### PR DESCRIPTION
This adds support for displaying the Status of the converter, as well as Lock Lights to display state of CapsLock, NumLock and ScrollLock, using a strip of WS2812 (NeoPixel) LEDs.

Different types of LED are also supported.  For development, I've used 4 x WS2812 NeoPixel LED's from Adafruit.  You can use any other type of WS2812-compatible NeoPixel, but please ensure you set the correct LED Type.  As part of this commit, only the following types are supported:

RGB (Red Green Blue)
RBG (Red Blue Green)
GRB (Green Red Blue)
GBR (Green Blue Red)
BRG (Blue Red Green)
BGR (Blue Green Red)

Please refer to common/lib/types.h for available options, this can be set within config.h by adjusting the following option

CONVERTER_LEDS_TYPE

I've not added support for 4-color NeoPixels (RGBW) as I don't have any to test, however this may come in a later update (or feel free to contribute).

LED Support can be toggled by commenting or uncommenting the following options within config.h

CONVERTER_LEDS      (Enable LED Support)
CONVERTER_LOCK_LEDS (Enable Lock Light LED Support)

By default, the following colours are set:

Converter Not Ready - Orange
Converter Ready     - Green
Lock LEDs           - Green
Entering Bootloader - Purple

PIO Code for driving the WS2812 NeoPixel LED was taken from the Pico-SDK pico-examples repository, and as such contains the original copyright header.

To support multiple PIO Code being applied to various State Machines, a new PIO Helper function has been defined to check each PIO for available space to apply the relevant PIO Program, and as such, will automatically choose either PIO 0 or PIO 1 depending where there is enough available space for the instructions (each PIO is limited to 32 total instructions, spread across a maximum of 4 State Machines per PIO).  Currently, all current PIO Code will safely sit within a single PIO instance, however, as more functionality is added, this will allow scaling.