### PR TITLE
Optimize ring buffer with memory barriers and function inlining

### DIFF
--- a/src/common/lib/ringbuf.h
+++ b/src/common/lib/ringbuf.h
@@ -155,7 +155,7 @@ __force_inline static uint8_t ringbuf_get(void) {
  * 
  * @param data The byte of data to be put into the ring buffer.
  * 
- * @warning No bounds checking - ovgiterwrites oldest data if buffer is full
+ * @warning No bounds checking - overwrites oldest data if buffer is full
  * @note Uses __force_inline for zero-overhead abstraction
  * @note Typically called from IRQ context - must be fast
  * 

--- a/src/common/lib/ringbuf.h
+++ b/src/common/lib/ringbuf.h
@@ -137,8 +137,8 @@ static inline bool ringbuf_is_full(void) {
  */
 __force_inline static uint8_t ringbuf_get(void) {
   uint8_t data = rbuf.buffer[rbuf.tail];
+  __dmb();  // Data Memory Barrier - ensure data read completes before tail update
   rbuf.tail = (rbuf.tail + 1) & rbuf.size_mask;
-  __dmb();  // Data Memory Barrier - ensure tail update is visible after data consumption
   return data;
 }
 

--- a/src/common/lib/ringbuf.h
+++ b/src/common/lib/ringbuf.h
@@ -164,8 +164,8 @@ __force_inline static uint8_t ringbuf_get(void) {
  */
 __force_inline static void ringbuf_put(uint8_t data) {
   rbuf.buffer[rbuf.head] = data;
+  __dmb();  // Data Memory Barrier - ensure data write is committed before head update
   rbuf.head = (rbuf.head + 1) & rbuf.size_mask;
-  __dmb();  // Data Memory Barrier - ensure head update is visible after data write
 }
 
 void ringbuf_reset(void);


### PR DESCRIPTION
This commit optimizes the lock-free ring buffer implementation used for IRQ-to-main-loop scancode queueing by adding explicit memory barriers and converting hot-path functions to inline implementations.

Changes:
- Add explicit __dmb() memory barriers in ringbuf_get() and ringbuf_put() to ensure proper memory ordering between IRQ and main contexts
- Convert critical functions to inline implementations to eliminate function call overhead (~5-10 cycles per operation):
  * ringbuf_is_empty() -> static inline
  * ringbuf_is_full() -> static inline
  * ringbuf_get() -> __force_inline static
  * ringbuf_put() -> __force_inline static
- Move ringbuf_t structure definition from .c to .h to enable inline function implementations
- Simplify ringbuf.c to only contain buffer storage and ringbuf_reset()

Performance Impact:
- Memory barriers: +1 cycle (ensures correctness on multi-core/DMA)
- Function inlining: -5 to -10 cycles (eliminates call overhead)
- Net improvement: ~4-9 cycles per round-trip (~32-72ns @ 125MHz)

The ring buffer maintains its lock-free SPSC (Single Producer Single Consumer) semantics while providing stronger memory ordering guarantees and reduced latency for scancode processing.

Technical Details:
- Uses ARM Cortex-M0+ DMB instruction via hardware/sync.h
- Inline functions compiled directly at call sites for zero overhead
- Buffer storage remains static in ringbuf.c for proper linkage
- ringbuf_reset() remains non-inline (rarely called, not time-critical)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a manual reset capability for the ring buffer to reinitialize head/tail in safe contexts.

- Refactor
  - Consolidated the ring buffer into a single global, fixed-size configuration.
  - Moved core operations to inlined accessors for lower latency and improved responsiveness.
  - Enhanced synchronization using memory barriers for safer multi-context access.
  - Removed console logging on buffer overflow to reduce debug noise.

- Documentation
  - Updated lifecycle and safety notes, including guidance on non-thread-safe reset usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->