### PR TITLE
Fix issue #19: Prevent duplicate keys in HID report

### DIFF
--- a/src/common/lib/hid_interface.c
+++ b/src/common/lib/hid_interface.c
@@ -135,15 +135,15 @@ static bool hid_keyboard_add_key(uint8_t key) {
   // Duplicate prevention approach to fix issue #19:
   // Single loop checks all 6 slots for duplicates while tracking first empty slot
   // Only adds key if: (1) not already present AND (2) empty slot available
-  uint8_t validSlot = 0xFF;  // 0xFF = no slot found (invalid index)
+  uint8_t validSlot = UINT8_MAX;  // Invalid slot sentinel
   for (uint8_t i = 0; i < 6; i++) {
     // Check for duplicate (already in report) - early return for performance
     if (keyboard_report.keycode[i] == key) {
       return false;  // Key already present, don't add again
     }
     // Remember first available slot (but don't use it yet!)
-    // Only check if we haven't found a slot yet (validSlot == 0xFF)
-    if (keyboard_report.keycode[i] == 0 && validSlot == 0xFF) {
+    // Only check if we haven't found a slot yet (validSlot == UINT8_MAX)
+    if (keyboard_report.keycode[i] == 0 && validSlot == UINT8_MAX) {
       validSlot = i;
     }
   }


### PR DESCRIPTION
Implemented fix for duplicate key bug where a key could appear twice in the HID report array when multiple keys are pressed/released in rapid succession (e.g., gaming, fast typing).

Root cause: Original implementation would add a key to an early empty slot before checking all remaining slots for duplicates.

Solution: Single-loop approach that scans all 6 slots to check for duplicates while tracking the first empty slot, then adds only if the key is not already present.

Implementation optimizations for RP2040/ARM Cortex-M0+:
- Use uint8_t types for loop counter and slot tracking (vs int/size_t)
- Use 0xFF sentinel value for invalid slot (vs -1)
- Unsigned comparison for slot validation (faster on ARM)
- Single loop with early return on duplicate (performance)

This prevents the edge case where:
1. Key A in slot 1, slot 0 empty
2. Duplicate press of Key A
3. Old code: adds A to slot 0 (now in slots 0 and 1)
4. New code: detects A in slot 1, returns false

Fixes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection and insertion logic to prevent duplicate entries, ensuring new items are only placed into the first available slot after a full scan. Preserves existing behaviour when storage is full. Results in more reliable input handling and fewer duplicate entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->